### PR TITLE
feat: Implement auth module

### DIFF
--- a/source/routes/auth/auth.module.ts
+++ b/source/routes/auth/auth.module.ts
@@ -1,0 +1,67 @@
+import Module from '@library/module';
+import S from 'fluent-json-schema';
+import userSchema from '@schemas/user';
+import verificationSchema from '@schemas/verification';
+import userLostPasswordSchema from '@schemas/userLostPassword';
+import postLoginController from './postLogin.controller';
+import postTokenController from './postToken.controller';
+import postVerificationController from './postVerification.controller';
+import postLostPasswordController from './postLostPassword.controller';
+import patchLostPasswordController from './patchLostPassword.controller';
+import dummyHandler from '@handlers/dummy';
+
+export default new Module('auth', [{
+	method: 'GET',
+	url: '',
+	excludePreHandler: true,
+	handler: dummyHandler
+}, {
+	method: 'POST',
+	url: 'login',
+	handler: postLoginController,
+	excludePreHandler: true,
+	schema: {
+		body: S.object()
+			.prop('email', userSchema['email'].required())
+			.prop('password', userSchema['password'].required())
+	}
+}, {
+	method: 'POST',
+	url: 'token',
+	handler: postTokenController,
+	excludePreHandler: true,
+	schema: {
+		body: S.object()
+			.prop('refreshToken', S.string()
+				.pattern(/(^[\w-]*\.[\w-]*\.[\w-]*$)/)
+				.required())
+	}
+}, {
+	method: 'POST',
+	url: 'verification',
+	handler: postVerificationController,
+	excludePreHandler: true,
+	schema: {
+		body: S.object()
+			.prop('email', verificationSchema['email'].required())
+	}
+}, {
+	method: 'POST',
+	url: 'lostPassword',
+	handler: postLostPasswordController,
+	excludePreHandler: true,
+	schema: {
+		body: S.object()
+			.prop('email', userSchema['email'].required())
+	}
+}, {
+	method: 'PATCH',
+	url: 'lostPassword',
+	handler: patchLostPasswordController,
+	excludePreHandler: true,
+	schema: {
+		body: S.object()
+			.prop('token', userLostPasswordSchema['token'].required())
+			.prop('password', userSchema['password'].required())
+	}
+}]);

--- a/source/routes/auth/patchLostPassword.controller.ts
+++ b/source/routes/auth/patchLostPassword.controller.ts
@@ -1,0 +1,44 @@
+import { encryptPbkdf2 } from '@library/crypto';
+import { kysely } from '@library/database';
+import { BadRequest } from '@library/httpError';
+import { Database, User, UserLostPassword } from '@library/type';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { Transaction, UpdateResult } from 'kysely';
+
+export default function (request: FastifyRequest<{
+	Body: Pick<UserLostPassword & User, 'token' | 'password'>;
+}>, reply: FastifyReply): Promise<void> {
+	return kysely.transaction()
+		.setAccessMode('read write')
+		.setIsolationLevel('serializable')
+		.execute(function (transaction: Transaction<Database>): Promise<void> {
+			let userId: User['id'];
+
+			return transaction.selectFrom('user_lost_password')
+				.innerJoin('user', 'user_lost_password.user_id', 'user.id')
+				.select(['user.id', 'user.email'])
+				.where('user_lost_password.token', '=', request['body']['token'])
+				.executeTakeFirst()
+				.then(function (user?: Pick<User, 'id' | 'email'>): Promise<string> {
+					if(user === undefined) {
+						throw new BadRequest('Body["token"] must be valid');
+					}
+
+					userId = user['id'];
+
+					return encryptPbkdf2(request['body']['password'], user['email']);
+				})
+				.then(function (encryptedPassword: string): Promise<UpdateResult> {
+					return kysely.updateTable('user')
+						.set({
+							password: encryptedPassword
+						})
+						.where('id', '=', userId)
+						.executeTakeFirstOrThrow();
+				})
+				.then(function (): void {
+					reply.status(204)
+						.send();
+				});
+		});
+}

--- a/source/routes/auth/postLogin.controller.ts
+++ b/source/routes/auth/postLogin.controller.ts
@@ -1,0 +1,57 @@
+import { encryptPbkdf2 } from '@library/crypto';
+import { kysely } from '@library/database';
+import { Unauthorized } from '@library/httpError';
+import JsonWebToken from '@library/jsonWebToken';
+import { Media, User } from '@library/type';
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+export default function (request: FastifyRequest<{
+	Body: Pick<User, 'email' | 'password'>;
+}>, reply: FastifyReply): Promise<void> {
+	let userAndMedia: Pick<User & Media, 'id' | 'email' | 'password' | 'name' | 'birthAt' | 'school' | 'hash' | 'type'>;
+
+	return kysely.selectFrom('user')
+		.select(['user.id', 'user.email', 'user.password', 'user.name', 'user.birth_at as birthAt', 'user.school'])
+		.innerJoin('media', 'user.media_id', 'media.id')
+		.select(['media.hash', 'media.type'])
+		.where('user.email', '=', request['body']['email'])
+		.where('user.deleted_at', 'is', null)
+		.executeTakeFirst()
+		.then(function (_userAndMedia?: typeof userAndMedia): Promise<string> {
+			if(_userAndMedia === undefined) {
+				throw new Unauthorized('Body["email"] and Body["password"] must be valid');
+			}
+
+			userAndMedia = _userAndMedia;
+
+			return encryptPbkdf2(request['body']['password'], request['body']['email']);
+		})
+		.then(function (encryptedPassword: string): void {
+			if(encryptedPassword !== userAndMedia['password']) {
+				throw new Unauthorized('Body["email"] and Body["password"] must be valid');
+			}
+
+			reply.send({
+				user: {
+					email: userAndMedia['email'],
+					name: userAndMedia['name'],
+					birthAt: userAndMedia['birthAt'],
+					school: userAndMedia['school'],
+					media: {
+						hash: userAndMedia['hash'],
+						type: userAndMedia['type']
+					}
+				},
+				token: {
+					refresh: JsonWebToken.create({
+						exp: Number['MAX_SAFE_INTEGER'],
+						uid: userAndMedia['id']
+					}, encryptedPassword),
+					access: JsonWebToken.create({
+						exp: JsonWebToken.getEpoch() + 7200,
+						uid: userAndMedia['id']
+					}, process['env']['JSON_WEB_TOKEN_SECRET'])
+				}
+			});
+		});
+}

--- a/source/routes/auth/postLostPassword.controller.ts
+++ b/source/routes/auth/postLostPassword.controller.ts
@@ -1,0 +1,48 @@
+import { LOST_PASSWORD_TEMPLATE } from '@library/constant';
+import { kysely, createUniqueToken } from '@library/database';
+import { BadRequest } from '@library/httpError';
+import { sendMail } from '@library/mailer';
+import { Database, User, UserLostPasswordTable } from '@library/type';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { Insertable, InsertResult, Transaction } from 'kysely';
+
+export default function (request: FastifyRequest<{
+	Body: Pick<User, 'email'>;
+}>, reply: FastifyReply): Promise<void> {
+	return kysely.transaction()
+		.setAccessMode('read write')
+		.setIsolationLevel('serializable')
+		.execute(function (transaction: Transaction<Database>): Promise<void> {
+			// lazy
+			const userLostPassword: Insertable<UserLostPasswordTable> = {} as Insertable<UserLostPasswordTable>;
+
+			return kysely.selectFrom('user')
+				.select('id')
+				.where('email', '=', request['body']['email'])
+				.where('deleted_at', 'is', null)
+				.executeTakeFirst()
+				.then(function (user?: Pick<User, 'id'>): Promise<string> {
+					if(user === undefined) {
+						throw new BadRequest('Body["email"] must be valid');
+					}
+
+					userLostPassword['user_id'] = user['id'];
+
+					return createUniqueToken(kysely, 'user_lost_password');
+				})
+				.then(function (token: string): Promise<InsertResult> {
+					userLostPassword['token'] = token;
+
+					return transaction.insertInto('user_lost_password')
+						.values(userLostPassword)
+						.executeTakeFirstOrThrow();
+				})
+				.then(function (): Promise<boolean> {
+					return sendMail(request['body']['email'], '[Flap] 비밀번호 재설정', LOST_PASSWORD_TEMPLATE.replace(/{token}/g, userLostPassword['token']));
+				})
+				.then(function (): void {
+					reply.status(204)
+						.send();
+				});
+		});
+}

--- a/source/routes/auth/postToken.controller.ts
+++ b/source/routes/auth/postToken.controller.ts
@@ -1,0 +1,39 @@
+import { kysely } from '@library/database';
+import { BadRequest } from '@library/httpError';
+import JsonWebToken from '@library/jsonWebToken';
+import { User } from '@library/type';
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+export default function (request: FastifyRequest<{
+	Body: {
+		refreshToken: string;
+	};
+}>, reply: FastifyReply): Promise<void> {
+	const refreshToken: JsonWebToken<{
+		uid: number;
+	}> = new JsonWebToken(request['body']['refreshToken'], '');
+
+	return kysely.selectFrom('user')
+		.select('password')
+		.where('id', '=', refreshToken['payload']['uid'])
+		.where('deleted_at', 'is', null)
+		.executeTakeFirst()
+		.then(function (user?: Pick<User, 'password'>): void {
+			if(user === undefined) {
+				throw new BadRequest('Body["refreshToken"] must be valid');
+			}
+
+			refreshToken['secretKey'] = user['password'];
+
+			if(!refreshToken.isValid()) {
+				throw new BadRequest('Body["refreshToken"] must be valid');
+			}
+
+			reply.send({
+				accessToken: JsonWebToken.create({
+					exp: JsonWebToken.getEpoch() + 7200,
+					uid: refreshToken['payload']['uid']
+				}, process['env']['JSON_WEB_TOKEN_SECRET'])
+			});
+		});
+}

--- a/source/routes/auth/postVerification.controller.ts
+++ b/source/routes/auth/postVerification.controller.ts
@@ -1,0 +1,54 @@
+import { VERIFICATION_TEMPLATE } from '@library/constant';
+import { kysely, createUniqueToken } from '@library/database';
+import { BadRequest } from '@library/httpError';
+import { sendMail } from '@library/mailer';
+import { Database, Verification } from '@library/type';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { InsertResult, OnConflictBuilder, OnConflictUpdateBuilder, sql, Transaction } from 'kysely';
+
+export default function (request: FastifyRequest<{
+	Body: Pick<Verification, 'email'>;
+}>, reply: FastifyReply): Promise<void> {
+	return kysely.transaction()
+		.setAccessMode('read write')
+		.setIsolationLevel('serializable')
+		.execute(function (transaction: Transaction<Database>): Promise<void> {
+			let token: string;
+
+			return kysely.selectFrom('user')
+				.select(sql.lit(1).as('v'))
+				.where('email', '=', request['body']['email'])
+				.executeTakeFirst()
+				.then(function (row?: {}): Promise<string> {
+					if(row !== undefined) {
+						throw new BadRequest('Body["email"] must be unique');
+					}
+
+					return createUniqueToken(kysely, 'verification');
+				})
+				.then(function (_token: string): Promise<InsertResult> {
+					token = _token;
+
+					return transaction.insertInto('verification')
+					.values({
+						email: request['body']['email'],
+						token: _token
+					})
+					// resend mail
+					.onConflict(function (builder: OnConflictBuilder<Database, 'verification'>): OnConflictUpdateBuilder<Database, 'verification'> {
+						return builder.column('email')
+							.doUpdateSet({
+								token: _token
+							});
+					})
+					.executeTakeFirstOrThrow();
+				})
+				.then(function (): Promise<boolean> {
+					return sendMail(request['body']['email'], '[Flap] 회원가입 메일 인증', VERIFICATION_TEMPLATE.replace(/{token}/g, token));
+				})
+				.then(function (): void {
+					reply.status(204)
+					.send();
+				});
+		});
+}

--- a/source/schemas/common.ts
+++ b/source/schemas/common.ts
@@ -1,0 +1,19 @@
+import S from 'fluent-json-schema';
+
+const commonSchema = {
+	id: S.integer()
+		.minimum(1)
+		.maximum(2147483648),
+	email: S.string()
+		.format('email'),
+	sha512: S.string()
+		.pattern(/^[0-9a-f]{128}$/),
+	token: S.string()
+		.pattern(/^[0-9a-f]{32}$/),
+	date: S.string()
+		.format('date'),
+	datetime: S.string()
+		.format('date-time'),
+} as const;
+
+export default commonSchema;

--- a/source/schemas/user.ts
+++ b/source/schemas/user.ts
@@ -1,0 +1,18 @@
+import { User } from '@library/type';
+import S, { JSONSchema } from 'fluent-json-schema';
+import commonSchema from './common';
+
+export default {
+	id: commonSchema['id'],
+	email: commonSchema['email'],
+	password: S.string()
+		.minLength(3),
+	name: S.string()
+		.minLength(2)
+		.maxLength(37),
+	school: S.string()
+		.minLength(10)
+		.maxLength(24),
+	birthAt: commonSchema['date'],
+	mediaId: commonSchema['id']
+} satisfies Record<keyof Omit<User, 'salt' | 'createdAt' | 'deletedAt'>, JSONSchema>;

--- a/source/schemas/userLostPassword.ts
+++ b/source/schemas/userLostPassword.ts
@@ -1,0 +1,9 @@
+import { UserLostPassword } from '@library/type';
+import { JSONSchema } from 'fluent-json-schema';
+import commonSchema from './common';
+import userSchema from './user';
+
+export default {
+	userId: userSchema['email'], // ref
+	token: commonSchema['token']
+} satisfies Record<keyof Omit<UserLostPassword, 'createdAt'>, JSONSchema>;

--- a/source/schemas/verification.ts
+++ b/source/schemas/verification.ts
@@ -1,0 +1,8 @@
+import { Verification } from '@library/type';
+import { JSONSchema } from 'fluent-json-schema';
+import commonSchema from './common';
+
+export default {
+	email: commonSchema['email'],
+	token: commonSchema['token']
+} satisfies Record<keyof Omit<Verification, 'createdAt'>, JSONSchema>;


### PR DESCRIPTION
## Objective
<!-- Pull Request의 목적 설명 -->
Implement auth module for login, email verification, token refresh, and lost password

## Changes
<!-- Commit들의 수정사항 요약 -->
- Adds following endpoints:<br>`[POST] /auth/login`, `[POST] /auth/token`, `[POST] /auth/verification`, `[POST] /auth/lostPassword`, and `[PATCH] /auth/lostPassword`
- Adds schemas for following tables:<br>`user`, `user_lost_password`, and `verification`

## Notes
<!-- 추가로 남길 말 -->
- Please use referenced schema for foreign key from now on (e.g. `userSchema['id']` for `userId`)